### PR TITLE
README: clarify running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # TaskGraph
-To run use ./run_local.sh.
+To run this locally, start by installing the dependencies:
 
-Your default browser should then launch at localhost:3000 along with the backend at localhost:3001.
+```
+npm install
+```
 
-Furthermore a docker container should start up running the mongodb backend.
+Then execute the launch script:
+
+```
+./run_local.sh
+```
+
+Your default browser should then launch at `localhost:3000`, along with the backend at `localhost:3001`.
+
+Furthermore, a Docker container should start up running the mongodb backend.
 
 Below is the documentation from the forked repository.
 


### PR DESCRIPTION
By the way, running `npm install` fails due to the execution of the `prepublish` script, which calls the `package` script, which runs, among other things, the `lint` and `test` scripts, both of which are currently failing. I'd recommend getting rid of the `prepublish` entry in `package.json`:

https://github.com/shuttle-hq/taskgraph/blob/590ad93a41bf7bc7c1dafca5e45ebec167c13792/package.json#L121

...just as a quick fix to make sure people can at least try this out locally.